### PR TITLE
fix root build option problem for fftw3 dependency 

### DIFF
--- a/share/swmod-instmod/installers/swmod-instmod-root.sh
+++ b/share/swmod-instmod/installers/swmod-instmod-root.sh
@@ -89,12 +89,12 @@ if [ -n "${FFTW3_PREFIX}" ] ; then
 	if [ -n "${FFTW3_MODNAME}" ] ; then
 		echo "FFTW3 loaded via swmod, will add ${FFTW3_MODNAME} to target package dependencies."
 
-		DEFAULT_BUILD_OPTS="${DEFAULT_BUILD_OPTS} --with-fftw3-incdir=${FFTW3_PREFIX}/include"
+		DEFAULT_BUILD_OPTS="${DEFAULT_BUILD_OPTS} -DFFTW_INCLUDE_DIR=${FFTW3_PREFIX}/include"
 
 		if \test -d "${FFTW3_PREFIX}/lib64" ; then
-			DEFAULT_BUILD_OPTS="${DEFAULT_BUILD_OPTS} --with-fftw3-libdir=${FFTW3_PREFIX}/lib64"
+			DEFAULT_BUILD_OPTS="${DEFAULT_BUILD_OPTS} -DFFTW_LIBRARY=${FFTW3_PREFIX}/lib64/libfftw3.so"
 		else
-			DEFAULT_BUILD_OPTS="${DEFAULT_BUILD_OPTS} --with-fftw3-libdir=${FFTW3_PREFIX}/lib"
+			DEFAULT_BUILD_OPTS="${DEFAULT_BUILD_OPTS} -DFFTW_LIBRARY=${FFTW3_PREFIX}/lib/libfftw3.so"
 		fi
 	fi
 fi


### PR DESCRIPTION
Hi @oschulz, @gipert,

I ran into some issues using swmod instmod to install root after https://github.com/oschulz/swmod-instmod-hep/pull/4.
The FFTW options seem to be the ones from the former "make" build options.
This PR contains what fixed it for me.

BTW: It seems that the `which fftw-wisdom` in https://github.com/oschulz/swmod-instmod-hep/blob/master/share/swmod-instmod/installers/swmod-instmod-root.sh#L86 will not work for FFTW3 versions >3.3.5 